### PR TITLE
Add Zenodo release archiving + MIT license (concept zenodo.11270119)

### DIFF
--- a/.github/workflows/zenodo-archive.yml
+++ b/.github/workflows/zenodo-archive.yml
@@ -1,0 +1,13 @@
+name: Archive release to Zenodo
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  archive:
+    uses: virtualcell/zenodo-maint/.github/workflows/archive.reusable.yml@v1
+    with:
+      tag: ${{ github.event.release.tag_name }}
+    secrets:
+      ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}

--- a/.github/workflows/zenodo-drift.yml
+++ b/.github/workflows/zenodo-drift.yml
@@ -1,0 +1,10 @@
+name: Zenodo drift check
+
+on:
+  schedule:
+    - cron: '0 12 * * 1'
+  workflow_dispatch: {}
+
+jobs:
+  drift:
+    uses: virtualcell/zenodo-maint/.github/workflows/drift.reusable.yml@v1

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,57 @@
+{
+  "upload_type": "software",
+  "title": "SpringSaLaD",
+  "license": "mit",
+  "creators": [
+    {
+      "name": "Michalski, Paul J.",
+      "affiliation": "University of Connecticut School of Medicine"
+    },
+    {
+      "name": "Loew, Leslie M.",
+      "affiliation": "University of Connecticut School of Medicine",
+      "orcid": "0000-0002-1851-4646"
+    },
+    {
+      "name": "Vasilescu, Dan",
+      "affiliation": "University of Connecticut School of Medicine"
+    },
+    {
+      "name": "Valencia, Ezequiel",
+      "affiliation": "University of Connecticut School of Medicine"
+    },
+    {
+      "name": "Schaff, James C.",
+      "affiliation": "University of Connecticut School of Medicine",
+      "orcid": "0000-0003-3286-7736"
+    },
+    {
+      "name": "Masison, Joseph",
+      "affiliation": "University of Connecticut School of Medicine",
+      "orcid": "0000-0003-2113-9282"
+    },
+    {
+      "name": "Moraru, Ion I.",
+      "affiliation": "University of Connecticut School of Medicine",
+      "orcid": "0000-0002-3746-9676"
+    }
+  ],
+  "description": "<p>SpringSaLaD is a particle-based, spatial, stochastic biochemical simulation platform. It implements a spatially-resolved stochastic simulation algorithm for biochemical systems based on the Langevin equation in a particle-based framework with excluded volume. The algorithm is described in Michalski &amp; Loew, &quot;SpringSaLaD: A Spatial, Particle-Based Biochemical Simulation Platform with Excluded Volume&quot; (Biophysical Journal, 2016; PMID 26840718). This is the Java implementation, developed at the Center for Cell Analysis and Modeling (CCAM) at UConn Health; the underlying solver is LangevinNoVis01 (https://github.com/cam-center/LangevinNoVis01).</p>",
+  "keywords": [
+    "stochastic simulation",
+    "spatial simulation",
+    "particle-based",
+    "Langevin dynamics",
+    "systems biology",
+    "biochemical reaction networks",
+    "excluded volume"
+  ],
+  "related_identifiers": [
+    {
+      "relation": "isDocumentedBy",
+      "identifier": "10.1016/j.bpj.2015.12.026",
+      "scheme": "doi",
+      "resource_type": "publication-article"
+    }
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,44 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using these metadata."
+title: "SpringSaLaD"
+type: software
+repository-code: "https://github.com/cam-center/SpringSaLaD"
+url: "https://vcell.org/ssalad"
+license: MIT
+doi: 10.5281/zenodo.11270119   # concept DOI (all versions)
+preferred-citation:
+  type: article
+  title: "SpringSaLaD: A Spatial, Particle-Based Biochemical Simulation Platform with Excluded Volume"
+  doi: 10.1016/j.bpj.2015.12.026
+  year: 2016
+  authors:
+    - family-names: "Michalski"
+      given-names: "Paul J."
+    - family-names: "Loew"
+      given-names: "Leslie M."
+authors:
+  - family-names: "Michalski"
+    given-names: "Paul J."
+    affiliation: "University of Connecticut School of Medicine"
+  - family-names: "Loew"
+    given-names: "Leslie M."
+    affiliation: "University of Connecticut School of Medicine"
+    orcid: "https://orcid.org/0000-0002-1851-4646"
+  - family-names: "Vasilescu"
+    given-names: "Dan"
+    affiliation: "University of Connecticut School of Medicine"
+  - family-names: "Valencia"
+    given-names: "Ezequiel"
+    affiliation: "University of Connecticut School of Medicine"
+  - family-names: "Schaff"
+    given-names: "James C."
+    affiliation: "University of Connecticut School of Medicine"
+    orcid: "https://orcid.org/0000-0003-3286-7736"
+  - family-names: "Masison"
+    given-names: "Joseph"
+    affiliation: "University of Connecticut School of Medicine"
+    orcid: "https://orcid.org/0000-0003-2113-9282"
+  - family-names: "Moraru"
+    given-names: "Ion I."
+    affiliation: "University of Connecticut School of Medicine"
+    orcid: "https://orcid.org/0000-0002-3746-9676"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 University of Connecticut
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Wires release archiving to Zenodo concept **10.5281/zenodo.11270119** via the `virtualcell/zenodo-maint` reusable workflow, replacing the native integration (now disabled). Adds a corrected author list, abstract, MIT license, and the SpringSaLaD paper citation.

- **CITATION.cff** — citation + concept DOI + preferred-citation (Michalski & Loew 2016)
- **.zenodo.json** — deposit metadata (7 authors, Ion Moraru last; abstract; MIT; paper related-identifier)
- **zenodo-archive.yml** / **zenodo-drift.yml** — archive on release + weekly drift
- **LICENSE** — MIT (repo had none)

`ZENODO_TOKEN` secret already configured. The 12 existing versions have already been updated with the corrected authors + abstract + MIT license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)